### PR TITLE
Correctly handle multiple apks in the play store

### DIFF
--- a/library/src/main/java/com/rampo/updatechecker/Comparator.java
+++ b/library/src/main/java/com/rampo/updatechecker/Comparator.java
@@ -60,15 +60,20 @@ public class Comparator {
         while (i < vals1.length && i < vals2.length && vals1[i].equals(vals2[i])) {
             i++;
         }
-        // compare first non-equal ordinal number
-        if (i < vals1.length && i < vals2.length) {
-            int diff = Integer.valueOf(vals1[i]).compareTo(Integer.valueOf(vals2[i]));
-            return Integer.signum(diff);
-        }
-        // the strings are equal or one string is a substring of the other
-        // e.g. "1.2.3" = "1.2.3" or "1.2.3" < "1.2.3.4"
-        else {
-            return Integer.signum(vals1.length - vals2.length);
+        try {
+            // compare first non-equal ordinal number
+            if (i < vals1.length && i < vals2.length) {
+                int diff = Integer.valueOf(vals1[i]).compareTo(Integer.valueOf(vals2[i]));
+                return Integer.signum(diff);
+            }
+            // the strings are equal or one string is a substring of the other
+            // e.g. "1.2.3" = "1.2.3" or "1.2.3" < "1.2.3.4"
+            else {
+                return Integer.signum(vals1.length - vals2.length);
+            }
+        } catch (NumberFormatException e) {
+            // Possibly there are different versions of the app in the store, so we can't check.
+            return 0;
         }
     }
 


### PR DESCRIPTION
Related to issue #1.
Currently if the retrieved version is "Varies depending on the device", the library will still try to compare the current and new version.
Since it will split on a "." and assumes the pieces are Integers, java will throw a NumberFormatException which isn't handled by the library.
This commit will handle the NumberFormatException and return 0, to say we're on the latest version.