### PR TITLE
Upgrade the library to use the support version of alert dialog.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.0.1'
+        classpath 'com.android.tools.build:gradle:1.2.2'
     }
 }
 
@@ -16,8 +16,8 @@ allprojects {
 ext {
     libraryPackageName = "com.rampo.updatechecker"
     minSdkVersion = 7
-    compileSdkVersion = 19
-    buildToolsVersion = "19.1.0"
+    compileSdkVersion = 22
+    buildToolsVersion = "22.0.1"
 }
 
 def isReleaseBuild() {

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.0.1'
+        classpath 'com.android.tools.build:gradle:1.2.2'
     }
 }
 repositories {
@@ -27,7 +27,7 @@ android {
     }
 }
 dependencies {
-    compile 'com.android.support:support-v4:19.0.1'
+    compile 'com.android.support:support-v4:22.1.1'
 }
 
 //apply from: '../maven_push.gradle'

--- a/library/src/main/java/com/rampo/updatechecker/notice/Dialog.java
+++ b/library/src/main/java/com/rampo/updatechecker/notice/Dialog.java
@@ -16,13 +16,13 @@
  */
 package com.rampo.updatechecker.notice;
 
-import android.app.AlertDialog;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
 import android.net.Uri;
+import android.support.v7.app.AlertDialog;
 import android.view.WindowManager;
 
 import com.rampo.updatechecker.R;


### PR DESCRIPTION
Reference: http://android-developers.blogspot.in/2015/04/android-support-library-221.html

Android now supports a unified theme experience using the support library. This merge is just updating the alert dialog to use the support version and upgrading the support version of the library.

Please test the changes from your end as well.

All the changed files: https://github.com/rampo/UpdateChecker/pull/112/files