### PR TITLE
Use context instead of activity

### DIFF
--- a/library/src/main/java/com/rampo/updatechecker/ASyncCheck.java
+++ b/library/src/main/java/com/rampo/updatechecker/ASyncCheck.java
@@ -62,10 +62,10 @@ class ASyncCheck extends AsyncTask<String, Integer, Integer> {
     ASyncCheckResult mResultInterface;
     String mVersionDownloadable;
 
-    ASyncCheck(Store store, ASyncCheckResult resultInterface, Context activity) {
+    ASyncCheck(Store store, ASyncCheckResult resultInterface, Context context) {
         this.mStore = store;
         this.mResultInterface = resultInterface;
-        this.mContext = activity;
+        this.mContext = context;
     }
 
     @Override

--- a/library/src/main/java/com/rampo/updatechecker/Comparator.java
+++ b/library/src/main/java/com/rampo/updatechecker/Comparator.java
@@ -16,6 +16,7 @@
 package com.rampo.updatechecker;
 
 import android.app.Activity;
+import android.content.Context;
 import android.content.pm.PackageManager;
 
 public class Comparator {
@@ -24,10 +25,10 @@ public class Comparator {
      *
      * @param versionDownloadable String to compare to the version installed of the app.
      */
-    public static boolean isVersionDownloadableNewer(Activity mActivity, String versionDownloadable) {
+    public static boolean isVersionDownloadableNewer(Context context, String versionDownloadable) {
         String versionInstalled = null;
         try {
-            versionInstalled = mActivity.getPackageManager().getPackageInfo(mActivity.getPackageName(), 0).versionName;
+            versionInstalled = context.getPackageManager().getPackageInfo(context.getPackageName(), 0).versionName;
         } catch (PackageManager.NameNotFoundException ignored) {
         }
         if (versionInstalled.equals(versionDownloadable)) { // If it is equal, no new version downloadable

--- a/library/src/main/java/com/rampo/updatechecker/UpdateChecker.java
+++ b/library/src/main/java/com/rampo/updatechecker/UpdateChecker.java
@@ -16,6 +16,7 @@
 package com.rampo.updatechecker;
 
 import android.app.Activity;
+import android.content.Context;
 import android.content.SharedPreferences;
 import android.support.v4.app.FragmentActivity;
 
@@ -41,7 +42,7 @@ public class UpdateChecker implements ASyncCheckResult, UpdateCheckerResult {
     static int DEFAULT_NOTICE_ICON_RES_ID = 0;
     static Notice DEFAULT_NOTICE = Notice.DIALOG;
 
-    static Activity mActivity;
+    static Context mRootContext;
     static Store mStore;
     static int mSuccessfulChecksRequired;
     static Notice mNotice;
@@ -50,8 +51,8 @@ public class UpdateChecker implements ASyncCheckResult, UpdateCheckerResult {
     static ASyncCheckResult mCheckResultCallback;
     static boolean mCustomImplementation;
 
-    public UpdateChecker(Activity activity) {
-        mActivity = activity;
+    public UpdateChecker(Context context) {
+        mRootContext = context;
         mStore = DEFAULT_STORE;
         mSuccessfulChecksRequired = DEFAULT_SUCCESSFUL_CHECKS_REQUIRED;
         mNotice = DEFAULT_NOTICE;
@@ -61,8 +62,8 @@ public class UpdateChecker implements ASyncCheckResult, UpdateCheckerResult {
         mCustomImplementation = false;
     }
 
-    public UpdateChecker(Activity activity, UpdateCheckerResult updateCheckerResult) {
-        mActivity = activity;
+    public UpdateChecker(Context context, UpdateCheckerResult updateCheckerResult) {
+        mRootContext = context;
         mStore = DEFAULT_STORE;
         mSuccessfulChecksRequired = DEFAULT_SUCCESSFUL_CHECKS_REQUIRED;
         mNotice = DEFAULT_NOTICE;
@@ -125,7 +126,7 @@ public class UpdateChecker implements ASyncCheckResult, UpdateCheckerResult {
      * Start the process
      */
     public static void start() {
-        ASyncCheck asynctask = new ASyncCheck(mStore, mCheckResultCallback, mActivity);
+        ASyncCheck asynctask = new ASyncCheck(mStore, mCheckResultCallback, mRootContext);
         asynctask.execute();
     }
 
@@ -136,7 +137,7 @@ public class UpdateChecker implements ASyncCheckResult, UpdateCheckerResult {
      */
     @Override
     public void versionDownloadableFound(String versionDownloadable) {
-        if (Comparator.isVersionDownloadableNewer(mActivity, versionDownloadable)) {
+        if (Comparator.isVersionDownloadableNewer(mRootContext, versionDownloadable)) {
             if (hasToShowNotice(versionDownloadable) && !hasUserTappedToNotShowNoticeAgain(versionDownloadable)) {
                 mLibraryResultCallaback.foundUpdateAndShowIt(versionDownloadable);
             } else {
@@ -249,7 +250,7 @@ public class UpdateChecker implements ASyncCheckResult, UpdateCheckerResult {
      * @see com.rampo.updatechecker.notice.Dialog#userHasTappedToNotShowNoticeAgain(android.content.Context, String)
      */
     private boolean hasUserTappedToNotShowNoticeAgain(String versionDownloadable) {
-        SharedPreferences prefs = mActivity.getSharedPreferences(PREFS_FILENAME, 0);
+        SharedPreferences prefs = mRootContext.getSharedPreferences(PREFS_FILENAME, 0);
         String prefKey = DONT_SHOW_AGAIN_PREF_KEY + versionDownloadable;
         return prefs.getBoolean(prefKey, false);
     }
@@ -258,7 +259,7 @@ public class UpdateChecker implements ASyncCheckResult, UpdateCheckerResult {
      * Show the Notice only if it's the first time or the number of the checks made is a multiple of the argument of setSuccessfulChecksRequired(int) method. (If you don't call setSuccessfulChecksRequired(int) the default is 5).
      */
     private boolean hasToShowNotice(String versionDownloadable) {
-        SharedPreferences prefs = mActivity.getSharedPreferences(PREFS_FILENAME, 0);
+        SharedPreferences prefs = mRootContext.getSharedPreferences(PREFS_FILENAME, 0);
         String prefKey = SUCCESSFUL_CHEKS_PREF_KEY + versionDownloadable;
         int mChecksMade = prefs.getInt(prefKey, 0);
         if (mChecksMade % mSuccessfulChecksRequired == 0 || mChecksMade == 0) {
@@ -275,7 +276,7 @@ public class UpdateChecker implements ASyncCheckResult, UpdateCheckerResult {
      */
     private void saveNumberOfChecksForUpdatedVersion(String versionDownloadable, int mChecksMade) {
         mChecksMade++;
-        SharedPreferences prefs = mActivity.getSharedPreferences(PREFS_FILENAME, 0);
+        SharedPreferences prefs = mRootContext.getSharedPreferences(PREFS_FILENAME, 0);
         SharedPreferences.Editor editor = prefs.edit();
         editor.putInt(SUCCESSFUL_CHEKS_PREF_KEY + versionDownloadable, mChecksMade);
         editor.commit();
@@ -286,14 +287,14 @@ public class UpdateChecker implements ASyncCheckResult, UpdateCheckerResult {
      * Show Dialog
      */
     public void showDialog(String versionDownloadable) {
-        Dialog.show(mActivity, mStore, versionDownloadable, mNoticeIconResId);
+        Dialog.show(mRootContext, mStore, versionDownloadable, mNoticeIconResId);
     }
 
     /**
      * Show Notification
      */
     public static void showNotification() {
-        Notification.show(mActivity, mStore, mNoticeIconResId);
+        Notification.show(mRootContext, mStore, mNoticeIconResId);
     }
 
     /**


### PR DESCRIPTION
The activity will leak since it's stored in a static variable